### PR TITLE
`name.lexeme.to_string()` instead of `name.to_string()`

### DIFF
--- a/src/interpreter/interpreter.rs
+++ b/src/interpreter/interpreter.rs
@@ -65,7 +65,9 @@ impl Interpreter {
             } => { self.evaluate_binary(left, operator, right) }
             Expr::Variable { 
                 name,
-            } => { self.environment.borrow().get(name )}
+            } => { 
+                self.environment.borrow().get(name)
+            }
             Expr::Grouping(inner) => self.evaluate(inner),
             Expr::Ternary {
                 condition,
@@ -134,7 +136,7 @@ impl Interpreter {
             None => Value::Nil,
         };
 
-        self.environment.borrow_mut().define(name.to_string(), value);
+        self.environment.borrow_mut().define(name.lexeme.to_string(), value);
         Ok(Value::Nil)
     } 
 

--- a/test.lox
+++ b/test.lox
@@ -6,3 +6,7 @@ for (var b = 1; a < 10000; b = temp + b) {
   temp = a;
   a = b;
 }
+
+var x = "Hey!";
+print x;
+


### PR DESCRIPTION
`name.lexeme.to_string()` it gives us the actual variable name text, while `name.to_string()` was giving us some other representation of the token that the environment couldn't use as a lookup key.