### PR TITLE
Finish expressions and statements; refactor `Expr` to be wrapped in Rc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12,5 +18,6 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 name = "rlox"
 version = "0.1.0"
 dependencies = [
+ "by_address",
  "once_cell",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+by_address = "1.2.1"
 once_cell = "1.21.3"
 
 [[bin]]

--- a/src/interpreter/interp.rs
+++ b/src/interpreter/interp.rs
@@ -22,10 +22,17 @@ use crate::{
 };
 use core::fmt;
 use std::{rc::Rc};
+use std::collections::HashMap;
+use by_address::ByAddress;
+
+type ExprRef<'source> = Rc<Expr<'source>>;
+type ExprKey<'source> = ByAddress<ExprRef<'source>>;
+
 
 pub struct Interpreter<'source> {
     pub globals: SharedEnv<'source>,
     pub environment: SharedEnv<'source>,
+    pub locals: HashMap<ExprKey<'source>, usize>,
 }
 
 #[derive(Debug, Clone)]
@@ -69,6 +76,7 @@ impl<'source> Interpreter<'source> {
         Interpreter {
             globals: globals.clone(),
             environment: globals,
+            locals: HashMap::new(),
         }
     }
 
@@ -184,6 +192,10 @@ impl<'source> Interpreter<'source> {
             }
             _ => unimplemented!(),
         }
+    }
+
+    pub fn resolve(&mut self, expr: Rc<Expr<'source>>, depth: usize) {
+        self.locals.insert(ByAddress(expr), depth);
     }
 
     pub fn execute_block(


### PR DESCRIPTION
The start of a major refactor to track pointer equality using Rc and ByAddress. 

This will really only affect sections of our interpreter where it's necessary to track source slices of our expressions.