### PR TITLE
Refactored `Expr` to pass Rc - pointer eqaulity

### DIFF
--- a/resolve.rs
+++ b/resolve.rs
@@ -1,8 +1,0 @@
-// resolve.rs
-// author: akrm al-hakimi
-// // Module for resolving variable and function declarations in the rlox interpreter
-
-use std::collections::HashMap;
-
-
-

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -12,52 +12,52 @@ use crate::{
     token::{Token, Literal},
     ast::stmt::Stmt,
 };
-use std::{fmt};
+use std::{fmt, rc::Rc};
 
 #[derive(Debug, Clone)]
 pub enum Expr<'source> {
     Assign {
         name: Token<'source>,
-        value: Box<Expr<'source>>,
+        value: Rc<Expr<'source>>,
     },
     Binary {
-        left: Box<Expr<'source>>,
+        left: Rc<Expr<'source>>,
         operator: Token<'source>,
-        right: Box<Expr<'source>>,
+        right: Rc<Expr<'source>>,
     },
     Call {
-        callee: Box<Expr<'source>>,
+        callee: Rc<Expr<'source>>,
         paren: Token<'source>,
-        args: Vec<Expr<'source>>,
+        args: Vec<Rc<Expr<'source>>>,
     },
     Unary {
         operator: Token<'source>,
-        right: Box<Expr<'source>>,
+        right: Rc<Expr<'source>>,
     },
     Mutate {
         operator: Token<'source>,
-        operand: Box<Expr<'source>>,
+        operand: Rc<Expr<'source>>,
         postfix: bool,
     },
     Variable {
         name: Token<'source>,
     },
     Ternary {
-        condition: Box<Expr<'source>>,
-        true_expr: Box<Expr<'source>>,
-        false_expr: Box<Expr<'source>>,
+        condition: Rc<Expr<'source>>,
+        true_expr: Rc<Expr<'source>>,
+        false_expr: Rc<Expr<'source>>,
     },
     Logical {
-        left: Box<Expr<'source>>,
+        left: Rc<Expr<'source>>,
         operator: Token<'source>,
-        right: Box<Expr<'source>>,
+        right: Rc<Expr<'source>>,
     },
     Lambda {
         params: Vec<Token<'source>>,
         body: Vec<Stmt<'source>>, 
     },
     Literal(Literal),
-    Grouping(Box<Expr<'source>>),
+    Grouping(Rc<Expr<'source>>),
 }
 
 impl <'source> Expr<'source> {
@@ -65,21 +65,21 @@ impl <'source> Expr<'source> {
     pub fn assignment(val_name: Token<'source>, value: Expr<'source>) -> Self {
         Self::Assign {
             name: val_name,
-            value: Box::new(value),
+            value: Rc::new(value),
         }
     }
     
     pub fn binary(left: Expr<'source>, op: Token<'source>, right: Expr<'source>) -> Self {
         Self::Binary { 
-            left: Box::new(left),
+            left: Rc::new(left),
             operator: op,
-            right:Box::new(right),
+            right: Rc::new(right),
         }
     }
 
-    pub fn call(callee: Expr<'source>, parentheses: Token<'source>, arguments: Vec<Expr<'source>>) -> Self {
+    pub fn call(callee: Expr<'source>, parentheses: Token<'source>, arguments: Vec<Rc<Expr<'source>>>) -> Self {
         Self::Call {
-            callee: Box::new(callee),
+            callee: Rc::new(callee),
             paren: parentheses,
             args: arguments,
         }
@@ -88,14 +88,14 @@ impl <'source> Expr<'source> {
     pub fn unary(op: Token<'source>, right: Expr<'source>) -> Self {
         Self::Unary { 
             operator: op,
-            right: Box::new(right),
+            right: Rc::new(right),
         }
     }
 
     pub fn mutate(opt: Token<'source>, op: Expr<'source>, pfix: bool) -> Self {
         Self::Mutate {
             operator: opt,
-            operand: Box::new(op),
+            operand: Rc::new(op),
             postfix: pfix,
         }
     }
@@ -108,17 +108,17 @@ impl <'source> Expr<'source> {
 
     pub fn ternary(cond: Expr<'source>, true_expr: Expr<'source>, false_expr: Expr<'source>) -> Self {
         Self::Ternary {
-            condition: Box::new(cond),
-            true_expr: Box::new(true_expr),
-            false_expr: Box::new(false_expr),
+            condition: Rc::new(cond),
+            true_expr: Rc::new(true_expr),
+            false_expr: Rc::new(false_expr),
         }
     }
 
     pub fn logical(left: Expr<'source>, op: Token<'source>, right: Expr<'source>) -> Self {
         Self::Logical {
-            left: Box::new(left),
+            left: Rc::new(left),
             operator: op,
-            right: Box::new(right),
+            right: Rc::new(right),
         }
     }
 
@@ -127,7 +127,7 @@ impl <'source> Expr<'source> {
     }
 
     pub fn grouping(expr: Expr<'source>) -> Self {
-        Expr::Grouping(Box::new(expr))
+        Expr::Grouping(Rc::new(expr))
     }
 
     pub fn lambda(paramaters: Vec<Token<'source>>, bod: Vec<Stmt<'source>>) -> Self {

--- a/src/ast/stmt.rs
+++ b/src/ast/stmt.rs
@@ -4,6 +4,7 @@
 
 use crate::ast::expr::Expr;
 use crate::token::Token;
+use std::rc::Rc;
 
 #[derive(Debug, Clone)]
 pub struct FunctionDecl<'source> {
@@ -16,28 +17,28 @@ pub struct FunctionDecl<'source> {
 pub enum Stmt<'source> {
     Class {
         name: Token<'source>,
-        superclass: Option<Expr<'source>>,
+        superclass: Option<Rc<Expr<'source>>>,
         methods: Vec<FunctionDecl<'source>>,
     },
     Block(Vec<Stmt<'source>>),
-    Expression(Expr<'source>),
+    Expression(Rc<Expr<'source>>),
     Function(FunctionDecl<'source>),
     If {
-        condition: Expr<'source>,
+        condition: Rc<Expr<'source>>,
         then_branch: Box<Stmt<'source>>,
         else_branch: Option<Box<Stmt<'source>>>,
     },
-    Print(Expr<'source>),
+    Print(Rc<Expr<'source>>),
     Return {
         keyword: Token<'source>,
-        value: Option<Expr<'source>>,
+        value: Option<Rc<Expr<'source>>>,
     },
     Var {
         name: Token<'source>,
-        initializer: Option<Expr<'source>>,
+        initializer: Option<Rc<Expr<'source>>>,
     },
     While {
-        condition: Expr<'source>,
+        condition: Rc<Expr<'source>>,
         body: Box<Stmt<'source>>,
     },
     Break {

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,7 +79,7 @@ fn run<'source>(source: &'source str, interpreter: &mut Interpreter<'source>) {
             if !source.contains(';') {
                 let mut expr_parser = Parser::new(tokens);
                 match expr_parser.expr() {
-                    Ok(expr) => match interpreter.evaluate(expr) {
+                    Ok(expr) => match interpreter.evaluate(expr.into()) {
                         Ok(value) => {
                             if !matches!(value, Value::Nil) {
                                 println!("{}", value);


### PR DESCRIPTION
- Replaced `Box<Expr>` with `Rc<Expr>` across the AST to allow shared ownership and enable pointer-based equality via`ByAddress`.
- Updated parser, resolver, and interpreter to propagate `Rc<Expr>` throughout expression handling.
- Adjusted `Stmt` variants and all `evaluate_*/resolve_*` methods to clone `Rc` where needed.
- Removed unnecessary `.clone()` on Copy types (e.g., `bool`).

This prepares the interpreter for `Eq`, `PartialEq`, and `Hash` support without manually implementing deep comparisons for `Expr`.