### PR TITLE
Resolver and refactoring

### DIFF
--- a/examples/resolution.lox
+++ b/examples/resolution.lox
@@ -1,0 +1,65 @@
+// Simple Resolver Test - Variable Resolution Examples
+
+print "=== RESOLVER TEST ===";
+
+// 1. Basic variable resolution
+var a = "global a";
+var b = "global b";
+
+{
+  var a = "local a";
+  print a; // Should print "local a"
+  print b; // Should print "global b"
+}
+
+print a; // Should print "global a"
+
+// 2. Function closures
+fn makeFunction() {
+  var local = "captured";
+  
+  fn inner() {
+    print local; // Should resolve to makeFunction's local
+  }
+  
+  return inner;
+}
+
+var closure = makeFunction();
+closure();
+
+// 3. Nested function scopes
+fn outer() {
+  var x = "outer x";
+  
+  fn middle() {
+    var y = "middle y";
+    
+    fn inner() {
+      print x; // Should resolve to outer's x
+      print y; // Should resolve to middle's y
+    }
+    
+    inner();
+  }
+  
+  middle();
+}
+
+outer();
+
+// 4. Variable shadowing
+var name = "global";
+
+fn test() {
+  print name; // global
+  
+  {
+    var name = "local";
+    print name; // local
+  }
+  
+  print name; // global again
+}
+
+test();

--- a/src/error/err.rs
+++ b/src/error/err.rs
@@ -50,6 +50,8 @@ pub enum RuntimeError<'source> {
 
 pub enum CompilerError<'source> {
     LocalVarDecl{ name: Token<'source>},
+    ExistingVar{ line: usize },
+    IllegalReturn{ keyword: Token<'source>},
 }
 
 impl fmt::Display for CompilerError<'_> {
@@ -57,6 +59,12 @@ impl fmt::Display for CompilerError<'_> {
         match self {
             CompilerError::LocalVarDecl { name } => {
                 write!(f, "Cannot read local variable in its own initializer. | Error: {}", name)
+            }
+            CompilerError::ExistingVar { line } => {
+                write!(f, "Already a variable with this name in this scope. | Found on line {}", line)
+            }
+            CompilerError::IllegalReturn { keyword } => {
+                write!(f, "Error: {} - Can't return from top level code. (line {})", keyword.lexeme, keyword.line)
             }
         }
     }

--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -2,174 +2,217 @@
 // author: akrm al-hakimi
 // // Module for resolving variable and function declarations in the rlox interpreter
 
-use std::{collections::HashMap};
+use std::collections::HashMap;
 
-
-use crate::{
-    ast::stmt::{
-        FunctionDecl,
-        Stmt,
-    },
-    error::CompilerError, 
-    interpreter::Interpreter
-};
 use crate::ast::expr::Expr;
 use crate::token::Token;
+use crate::{
+    ast::stmt::{FunctionDecl, Stmt},
+    error::CompilerError,
+    interpreter::Interpreter,
+};
 use std::rc::Rc;
 
-pub struct Resolver<'source> {
-    interpreter: &'source mut Interpreter<'source>,
-    scopes: Vec<HashMap<String, bool>>,
-    errors: Vec<CompilerError<'source>>
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum FunctionType {
+    None,
+    Function,
 }
 
-impl <'source> Resolver <'source> {
+pub struct Resolver<'source> {
+    scopes: Vec<HashMap<String, bool>>,
+    errors: Vec<CompilerError<'source>>,
+    current_function: FunctionType,
+}
 
-    pub fn new(interpreter: &'source mut Interpreter<'source>, scopes: Vec<HashMap<String, bool>>, errors: Vec<CompilerError<'source>>) -> Self {
+#[allow(clippy::needless_lifetimes)]
+impl<'source> Default for Resolver<'source> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<'source> Resolver<'source> {
+    pub fn new() -> Self {
         Self {
-            interpreter,
-            scopes,
-            errors,
+            scopes: Vec::new(),
+            errors: Vec::new(),
+            current_function: FunctionType::None,
         }
     }
 
-    pub fn resolve_stmts(&mut self, stmts: &[Stmt<'source>]) {
+    pub fn resolve_stmts(
+        &mut self,
+        stmts: &[Stmt<'source>],
+        interpreter: &mut Interpreter<'source>,
+    ) {
         for stmt in stmts {
-            self.resolve_stmt(stmt);
+            self.resolve_stmt(stmt, interpreter);
         }
     }
 
-    fn resolve_stmt(&mut self, stmt: &Stmt<'source>) {
+    fn resolve_stmt(&mut self, stmt: &Stmt<'source>, interpreter: &mut Interpreter<'source>) {
         match stmt {
             Stmt::Block(stmts) => {
                 self.begin_scope();
-                self.resolve_stmts(stmts);
+                self.resolve_stmts(stmts, interpreter);
                 self.end_scope();
-            },
-            Stmt::Var{name, initializer} => {
-                self.declare(&name.clone());
+            }
+            Stmt::Var { name, initializer } => {
+                self.declare(name);
                 if let Some(expr) = initializer {
-                    self.resolve_expr(expr);
+                    self.resolve_expr(expr, interpreter);
                 }
-                self.define(&name.clone());
-            },
-            Stmt::Function(stmt) => {
-                if let Some(name) = &stmt.name {
+                self.define(name);
+            }
+            Stmt::Function(func) => {
+                if let Some(name) = &func.name {
                     self.declare(name);
                     self.define(name);
                 }
-                self.resolve_function(stmt);
-            },
-            Stmt::Expression(expr) => {
-                self.resolve_expr(expr);
-            },
-            Stmt::If { condition, then_branch, else_branch } => {
-                self.resolve_expr(condition);
-                self.resolve_stmt(then_branch);
+                self.resolve_function(func, interpreter, FunctionType::Function);
+            }
+            Stmt::Expression(expr) => self.resolve_expr(expr, interpreter),
+            Stmt::If {
+                condition,
+                then_branch,
+                else_branch,
+            } => {
+                self.resolve_expr(condition, interpreter);
+                self.resolve_stmt(then_branch, interpreter);
                 if let Some(else_branch_stmt) = else_branch {
-                    self.resolve_stmt(else_branch_stmt);
+                    self.resolve_stmt(else_branch_stmt, interpreter);
                 }
-            },
-            Stmt::Print(expr) => {
-                self.resolve_expr(expr);
-            },
-            Stmt::Return { keyword: _, value: Some(value) } => {
-                self.resolve_expr(value);
-            },
+            }
+            Stmt::Print(expr) => self.resolve_expr(expr, interpreter),
+            Stmt::Return { keyword, value } => {
+                if self.current_function == FunctionType::None {
+                    self.errors.push(CompilerError::IllegalReturn {
+                        keyword: keyword.clone(),
+                    });
+                }
+                if let Some(value) = value {
+                    self.resolve_expr(value, interpreter);
+                }
+            }
             Stmt::While { condition, body } => {
-                self.resolve_expr(condition);
-                self.resolve_stmt(body);
-            },
-            _ => {},
+                self.resolve_expr(condition, interpreter);
+                self.resolve_stmt(body, interpreter);
+            }
+            _ => {}
         }
     }
 
-    fn resolve_expr(&mut self, expr: &Rc<Expr<'source>>) {
+    fn resolve_expr(&mut self, expr: &Rc<Expr<'source>>, interpreter: &mut Interpreter<'source>) {
         match &**expr {
             Expr::Variable { name } => {
                 if !self.scopes.is_empty() {
                     if let Some(scope) = self.scopes.last() {
                         if let Some(false) = scope.get(name.lexeme) {
-                            self.errors.push(CompilerError::LocalVarDecl { name: name.clone() });
+                            self.errors
+                                .push(CompilerError::LocalVarDecl { name: name.clone() });
                         }
                     }
                 }
-            },
-            Expr::Assign { name, value} => {
-                self.resolve_expr(value);
-                self.resolve_local(expr.clone(), name);
-            },
-            Expr::Binary { left, operator: _, right } => {
-                self.resolve_expr(left);
-                self.resolve_expr(right);
-            },
-            Expr::Call { callee, paren: _, args } => {
-                self.resolve_expr(callee);
-                for argument in args {
-                    self.resolve_expr(argument);
+                self.resolve_local(expr.clone(), name, interpreter);
+            }
+            Expr::Assign { name, value } => {
+                self.resolve_expr(value, interpreter);
+                self.resolve_local(expr.clone(), name, interpreter);
+            }
+            Expr::Binary {
+                left,
+                operator: _,
+                right,
+            } => {
+                self.resolve_expr(left, interpreter);
+                self.resolve_expr(right, interpreter);
+            }
+            Expr::Call {
+                callee,
+                paren: _,
+                args,
+            } => {
+                self.resolve_expr(callee, interpreter);
+                for arg in args {
+                    self.resolve_expr(arg, interpreter);
                 }
-            },
-            Expr::Grouping(expr) => {
-                self.resolve_expr(expr);
-            },
-            Expr::Literal(_) => {},
-            Expr::Logical { left, operator: _, right } => {
-                self.resolve_expr(left);
-                self.resolve_expr(right);
-            },
-            Expr::Unary { operator: _, right } => {
-                self.resolve_expr(right);
-            },
-           _ => unimplemented!()
+            }
+            Expr::Grouping(expr) => self.resolve_expr(expr, interpreter),
+            Expr::Logical {
+                left,
+                operator: _,
+                right,
+            } => {
+                self.resolve_expr(left, interpreter);
+                self.resolve_expr(right, interpreter);
+            }
+            Expr::Unary { operator: _, right } => self.resolve_expr(right, interpreter),
+            Expr::Literal(_) => {}
+            _ => unimplemented!(),
         }
     }
 
+
+    fn resolve_local(
+        &mut self,
+        expr: Rc<Expr<'source>>,
+        name: &Token<'source>,
+        interpreter: &mut Interpreter<'source>,
+    ) {
+        for i in (0..self.scopes.len()).rev() {
+            if self.scopes[i].contains_key(name.lexeme) {
+                let depth = self.scopes.len() - 1 - i;
+                interpreter.resolve(expr, depth);
+                return;
+            }
+        }
+    }
+
+    fn resolve_function(
+        &mut self,
+        function: &FunctionDecl<'source>,
+        interpreter: &mut Interpreter<'source>,
+        func_type: FunctionType,
+    ) {
+        let enclosing_func = self.current_function;
+        self.current_function = func_type;
+
+        self.begin_scope();
+        for param in &function.params {
+            self.declare(param);
+            self.define(param);
+        }
+        self.resolve_stmts(&function.body, interpreter);
+        self.end_scope();
+        self.current_function = enclosing_func;
+    }
+
     fn begin_scope(&mut self) {
-        self.scopes.push(HashMap::new())
+        self.scopes.push(HashMap::new());
     }
 
     fn end_scope(&mut self) {
         self.scopes.pop();
     }
 
-    fn declare(&mut self, name: &Token) {
-        if self.scopes.is_empty() {
-            return;
-        }
-        if let Some(scope) = self.scopes.last_mut(){
+    fn declare(&mut self, name: &Token<'source>) {
+        if let Some(scope) = self.scopes.last_mut() {
+            if scope.contains_key(name.lexeme) {
+                self.errors
+                    .push(CompilerError::ExistingVar { line: name.line })
+            }
             scope.insert(name.lexeme.to_string(), false);
-        } 
+        }
     }
 
-    fn define(&mut self, name: &Token) {
-        if self.scopes.is_empty() {
-            return;
-        }
-
+    fn define(&mut self, name: &Token<'source>) {
         if let Some(scope) = self.scopes.last_mut() {
             scope.insert(name.lexeme.to_string(), true);
         }
     }
 
-    fn resolve_local(&mut self, expr: Rc<Expr<'source>>, name: &Token) {
-        for (i, scope) in self.scopes.iter().enumerate().rev() {
-            if scope.contains_key(name.lexeme) {
-                let depth = self.scopes.len() - 1 - i;
-                self.interpreter.resolve(expr, depth);
-                return;
-            }
-        }
-    }
-
-    fn resolve_function(&mut self, function: &FunctionDecl<'source> ) {
-        self.begin_scope();
-
-        for param in &function.params {
-            self.declare(param);
-            self.define(param);
-        }
-
-        self.resolve_stmts(&function.body);
-        self.end_scope();
+    pub fn take_errors(self) -> Vec<CompilerError<'source>> {
+        self.errors
     }
 }


### PR DESCRIPTION
Implemented the the resolver and included several interpreter improvements for better performance and cleaner code organization.

- Added complete resolver module for static variable resolution
- Calculates and stores scope depths for variable lookups
- Integrated resolver into the main REPL pipeline
- Changed `execute()` to take `&Stmt` instead of `Stmt` to eliminate unnecessary cloning during execution and improve performance
- Refactored block statement handling to use existing `execute_block()` method directly

### Bug Fixes
- Fixed expression statements no longer printing unwanted `nil` values
- Improved error handling for variable resolution edge cases